### PR TITLE
fix oculus executable path

### DIFF
--- a/BOXVR Playlist Manager/App.xaml.cs
+++ b/BOXVR Playlist Manager/App.xaml.cs
@@ -140,7 +140,7 @@ namespace BoxVR_Playlist_Manager
 
                     foreach(var mountPoint in mountPoints)
                     {
-                        var location = Path.Combine(mountPoint, "Software", "fitxr-boxvr");
+                        var location = Path.Combine(mountPoint, "Software", "fitxr-boxvr\\BoxVR_Oculus");
                         if (File.Exists(Path.Combine(location, "BoxVR.exe")))
                         {
                             logger.Debug($"BoxVR located in Oculus library: {location}");


### PR DESCRIPTION
Hi,

The BoxVR.exe file for Oculus is located in `C:\Program Files\Oculus\Software\Software\fitxr-boxvr\BoxVR_Oculus` so while the logic is correct in v1.1.1 it was missing that `BoxVR_Oculus` subdir.

Log from BoxVR.Playlist.Manager.v1.1.1: [2018-11-18.log](https://github.com/GeekJosh/BoxVR-Playlist-Manager/files/2592672/2018-11-18.log) - does not find file

Log from fork with fix: [2018-11-18.log](https://github.com/GeekJosh/BoxVR-Playlist-Manager/files/2592671/2018-11-18.log)  - finds file
